### PR TITLE
feat(alb): ssl certificate and https listener

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -42,3 +42,20 @@ resource "aws_alb_listener" "alb_listener" {
     type             = "forward"
   }
 }
+
+resource "aws_alb_listener" "https_ssl" {
+  load_balancer_arn = aws_alb.alb.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  depends_on        = [aws_alb_target_group.alb_tg]
+   
+  default_action {
+    target_group_arn = aws_alb_target_group.alb_tg.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener_certificate" "https_ssl_cert" {
+  listener_arn    = aws_alb_listener.https_ssl.arn
+  certificate_arn = "arn:aws:acm:ap-southeast-2:00012345678:certificate/abcd-abcd-abcd-4321-abcd"
+}


### PR DESCRIPTION
Tickets: https://github.com/devopsacademyau/2020-jun-project1-group2/issues/9 https://github.com/devopsacademyau/2020-jun-project1-group2/issues/38

- Added now ssl certificate
- Created a alb listener port 443 and linked to the certificate

ALB its already connected to the ECS and its public accessible by port 80